### PR TITLE
vSphere Provider: If we only have one networkInterface, deviceID should

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -1053,6 +1053,9 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 						}
 						if gatewaySetting != "" {
 							deviceID, err := strconv.Atoi(route.Gateway.Device)
+							if len(networkInterfaces) == 1 {
+								deviceID = 0
+							}
 							if err != nil {
 								log.Printf("[WARN] error at processing %s of device id %#v: %#v", gatewaySetting, route.Gateway.Device, err)
 							} else {


### PR DESCRIPTION
be 0 to ensure that it selects the first element of the
networkInterfaces array.